### PR TITLE
Fix runtime and ID extraction when parsing simulator status

### DIFF
--- a/Sources/mendoza/CommandLineProxy/CommandLineSimulators.swift
+++ b/Sources/mendoza/CommandLineProxy/CommandLineSimulators.swift
@@ -204,7 +204,7 @@ extension CommandLineProxy {
             // We use 'instruments -s devices' instead of 'xcrun simctl list devices' because it gives more complete infos including simulator version
             let simulatorsStatus = try cachedSimulatorStatus ?? rawSimulatorStatus()
 
-            let statusRegex = try NSRegularExpression(pattern: #"(.*?)\s(Simulator\s)?\((.*)\)\s\((.*)\)$"#)
+            let statusRegex = try NSRegularExpression(pattern: #"(.*?)\s(Simulator\s)?\((\d+\.\d+(?:\.\d+)?)\)\s\(([0-9a-fA-F-]+)\)$"#)
 
             let simulatorStatus: (String) -> (String, String, String)? = { rawStatus in
                 let captureGroups = rawStatus.capturedGroups(regex: statusRegex)


### PR DESCRIPTION
This PR follows up #20 and intends to fix support for device names that contains parentheses, allowing the correct extraction of name, simulator runtime and ID from the output of the `xcrun xctrace list devices` command.

Output lines look like this:

`iPad (10th generation)-1 (17.0.1) (CA78EE68-38E9-4C48-A5C2-3E6C8C737282)`

The previous regex would wrongly capture _iPad_ as device name, and _10th generation)-1 (17.0.1_ as runtime version. This would make it impossible to match the simulator runtime version, and result in the creation of a new simulator for each UI test run.